### PR TITLE
Fix 16 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -8,7 +8,7 @@ backoff==2.2.1
     # via opentelemetry-exporter-otlp-proto-grpc
 cachetools==5.2.0
     # via google-auth
-certifi==2022.12.7
+certifi == 2023.07.22 
     # via requests
 charset-normalizer==2.1.1
     # via requests
@@ -40,16 +40,16 @@ googleapis-common-protos==1.57.0
     #   google-api-core
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-grpc
-grpcio==1.51.1
+grpcio == 1.53.0 
     # via
     #   -r requirements.in
     #   google-api-core
     #   grpcio-health-checking
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-grpc
-grpcio-health-checking==1.51.1
+grpcio == 1.53.0 
     # via -r requirements.in
-grpcio-status==1.51.1
+grpcio == 1.53.0 
     # via google-api-core
 httplib2==0.21.0
     # via
@@ -72,11 +72,11 @@ opentelemetry-distro==0.36b0
     # via -r requirements.in
 opentelemetry-exporter-otlp-proto-grpc==1.15.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.36b0
+opentelemetry-instrumentation == 0.41b0 
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-grpc
-opentelemetry-instrumentation-grpc==0.36b0
+opentelemetry-instrumentation == 0.41b0 
     # via -r requirements.in
 opentelemetry-proto==1.15.0
     # via opentelemetry-exporter-otlp-proto-grpc
@@ -112,7 +112,7 @@ pyparsing==3.0.9
     # via httplib2
 python-json-logger==2.0.4
     # via -r requirements.in
-requests==2.28.1
+requests == 2.31.0 
     # via
     #   -r requirements.in
     #   google-api-core
@@ -127,7 +127,7 @@ typing-extensions==4.4.0
     # via opentelemetry-sdk
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.13
+urllib3 == 2.0.7 
     # via requests
 wrapt==1.14.1
     # via

--- a/src/loadgenerator/requirements.txt
+++ b/src/loadgenerator/requirements.txt
@@ -6,7 +6,7 @@
 #
 brotli==1.0.9
     # via geventhttpclient
-certifi==2022.12.7
+certifi == 2023.07.22 
     # via
     #   geventhttpclient
     #   requests
@@ -16,20 +16,20 @@ click==8.1.3
     # via flask
 configargparse==1.5.3
     # via locust
-flask==2.2.2
+flask == 2.3.2 
     # via
     #   flask-basicauth
     #   flask-cors
     #   locust
-flask-basicauth==0.2.0
+flask == 2.3.2 
     # via locust
-flask-cors==3.0.10
+flask == 2.3.2 
     # via locust
-gevent==22.10.2
+gevent == 23.9.0 
     # via
     #   geventhttpclient
     #   locust
-geventhttpclient==2.0.8
+gevent == 23.9.0 
     # via locust
 greenlet==2.0.1
     # via gevent
@@ -53,7 +53,7 @@ psutil==5.9.4
     # via locust
 pyzmq==24.0.1
     # via locust
-requests==2.28.1
+requests == 2.31.0 
     # via locust
 roundrobin==0.0.4
     # via locust
@@ -63,9 +63,9 @@ six==1.16.0
     #   geventhttpclient
 typing-extensions==4.4.0
     # via locust
-urllib3==1.26.13
+urllib3 == 2.0.7 
     # via requests
-werkzeug==2.2.2
+werkzeug == 3.0.1 
     # via
     #   flask
     #   locust

--- a/src/recommendationservice/requirements.txt
+++ b/src/recommendationservice/requirements.txt
@@ -8,7 +8,7 @@ backoff==2.2.1
     # via opentelemetry-exporter-otlp-proto-grpc
 cachetools==5.2.0
     # via google-auth
-certifi==2022.12.7
+certifi == 2023.07.22 
     # via requests
 charset-normalizer==2.1.1
     # via requests
@@ -36,12 +36,12 @@ googleapis-common-protos==1.57.0
     # via
     #   google-api-core
     #   opentelemetry-exporter-otlp-proto-grpc
-grpcio==1.51.1
+grpcio == 1.53.0 
     # via
     #   -r requirements.in
     #   grpcio-health-checking
     #   opentelemetry-exporter-otlp-proto-grpc
-grpcio-health-checking==1.51.1
+grpcio == 1.53.0 
     # via -r requirements.in
 httplib2==0.21.0
     # via
@@ -60,11 +60,11 @@ opentelemetry-distro==0.36b0
     # via -r requirements.in
 opentelemetry-exporter-otlp-proto-grpc==1.15.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.36b0
+opentelemetry-instrumentation == 0.41b0 
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-grpc
-opentelemetry-instrumentation-grpc==0.36b0
+opentelemetry-instrumentation == 0.41b0 
     # via -r requirements.in
 opentelemetry-proto==1.15.0
     # via opentelemetry-exporter-otlp-proto-grpc
@@ -95,7 +95,7 @@ pyparsing==3.0.9
     # via httplib2
 python-json-logger==2.0.4
     # via -r requirements.in
-requests==2.28.1
+requests == 2.31.0 
     # via
     #   -r requirements.in
     #   google-api-core
@@ -112,7 +112,7 @@ typing-extensions==4.4.0
     # via opentelemetry-sdk
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.13
+urllib3 == 2.0.7 
     # via requests
 wrapt==1.14.1
     # via


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Fri, 29 Dec 2023 11:58:27 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | src/emailservice/requirements.txt | certifi | [CVE-2023-37920](https://nvd.nist.gov/vuln/detail/CVE-2023-37920) | 9.8 | fixed in 2023.07.22 | Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi prior to version 2023.07.22 recognizes \"e-Tugra\" root certificates. e-Tugra\'s root certificates were subject to an investigation prompted by reporting of security issues in their systems. Certifi 2023.07.22 removes root certificates from \"e-Tugra\" from the root store.
critical | src/loadgenerator/requirements.txt | certifi | [CVE-2023-37920](https://nvd.nist.gov/vuln/detail/CVE-2023-37920) | 9.8 | fixed in 2023.07.22 | Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi prior to version 2023.07.22 recognizes \"e-Tugra\" root certificates. e-Tugra\'s root certificates were subject to an investigation prompted by reporting of security issues in their systems. Certifi 2023.07.22 removes root certificates from \"e-Tugra\" from the root store.
critical | src/loadgenerator/requirements.txt | gevent | [CVE-2023-41419](https://nvd.nist.gov/vuln/detail/CVE-2023-41419) | 9.8 | fixed in 23.9.0 | An issue in Gevent before version 23.9.0 allows a remote attacker to escalate privileges via a crafted script to the WSGIServer component.
critical | src/recommendationservice/requirements.txt | certifi | [CVE-2023-37920](https://nvd.nist.gov/vuln/detail/CVE-2023-37920) | 9.8 | fixed in 2023.07.22 | Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi prior to version 2023.07.22 recognizes \"e-Tugra\" root certificates. e-Tugra\'s root certificates were subject to an investigation prompted by reporting of security issues in their systems. Certifi 2023.07.22 removes root certificates from \"e-Tugra\" from the root store.
critical | src/paymentservice/package-lock.json | protobufjs | [CVE-2023-36665](https://nvd.nist.gov/vuln/detail/CVE-2023-36665) | 9.8 | fixed in 7.2.5 | \"protobuf.js (aka protobufjs) 6.10.0 through 7.x before 7.2.5 allows Prototype Pollution, a different vulnerability than CVE-2022-25878. A user-controlled protobuf message can be used by an attacker to pollute the prototype of Object.prototype by adding and overwriting its data and functions. Exploitation can involve: (1) using the function parse to parse protobuf messages on the fly, (2) loading .proto files by using load/loadSync functions, or (3) providing untrusted input to the functions ReflectionObject.setParsedOption and util.setProperty.
high | src/emailservice/requirements.txt | grpcio | [CVE-2023-1428](https://nvd.nist.gov/vuln/detail/CVE-2023-1428) | 7.5 | fixed in 1.53.0 | There exists an vulnerability causing an abort() to be called in gRPC.u00a0 The following headers cause gRPC\'s C++ implementation to abort() when called via http2:  te: x (x != trailers)  :scheme: x (x != http, https)  grpclb_client_stats: x (x == anything)  On top of sending one of those headers, a later header must be sent that gets the total header size past 8KB. We recommend upgrading past git commitu00a02485fa94bd8a723e5c977d55a3ce10b301b437f8 or v1.53 and above.  
high | src/emailservice/requirements.txt | grpcio | [CVE-2023-32731](https://nvd.nist.gov/vuln/detail/CVE-2023-32731) | 7.4 | fixed in 1.53.0 | When gRPC HTTP2 stack raised a header size exceeded error, it skipped parsing the rest of the HPACK frame. This caused any HPACK table mutations to also be skipped, resulting in a desynchronization of HPACK tables between sender and receiver. If leveraged, say, between a proxy and a backend, this could lead to requests from the proxy being interpreted as containing headers from different proxy clients - leading to an information leak that can be used for privilege escalation or data exfiltration. We recommend upgrading beyond the commit contained inu00a0 https://github.com/grpc/grpc/pull/33005 https://github.com/grpc/grpc/pull/33005  
high | src/emailservice/requirements.txt | opentelemetry-instrumentation | [CVE-2023-43810](https://nvd.nist.gov/vuln/detail/CVE-2023-43810) | 7.5 | fixed in 0.41b0 | OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, logs. Autoinstrumentation out of the box adds the label `http_method` that has unbound cardinality. It leads to the server\'s potential memory exhaustion when many malicious requests are sent. HTTP method for requests can be easily set by an attacker to be random and long. In order to be affected program has to be instrumented for HTTP handlers and does not filter any unknown HTTP methods on the level of CDN, LB, previous middleware, etc. This issue has been patched in version 0.41b0.
high | src/emailservice/requirements.txt | urllib3 | [CVE-2023-43804](https://nvd.nist.gov/vuln/detail/CVE-2023-43804) | 8.1 | fixed in 2.0.6, 1.26.17 | urllib3 is a user-friendly HTTP client library for Python. urllib3 doesn\'t treat the `Cookie` HTTP header special or provide any helpers for managing cookies over HTTP, that is the responsibility of the user. However, it is possible for a user to specify a `Cookie` header and unknowingly leak information via HTTP redirects to a different origin if that user doesn\'t disable redirects explicitly. This issue has been patched in urllib3 version 1.26.17 or 2.0.5.
high | src/loadgenerator/requirements.txt | flask | [CVE-2023-30861](https://nvd.nist.gov/vuln/detail/CVE-2023-30861) | 7.5 | fixed in 2.3.2, 2.2.5 | Flask is a lightweight WSGI web application framework. When all of the following conditions are met, a response containing data intended for one client may be cached and subsequently sent by the proxy to other clients. If the proxy also caches `Set-Cookie` headers, it may send one client\'s `session` cookie to other clients. The severity depends on the application\'s use of the session and the proxy\'s behavior regarding cookies. The risk depends on all these conditions being met.  1. The application must be hosted behind a caching proxy that does not strip cookies or ignore responses with cookies. 2. The application sets `session.permanent = True` 3. The application does not access or modify the session at any point during a request. 4. `SESSION_REFRESH_EACH_REQUEST` enabled (the default). 5. The application does not set a `Cache-Control` header to indicate that a page is private or should not be cached.  This happens because vulnerable versions of Flask only set the `Vary: Cookie` header when the session is accessed or modified, not when it is refreshed (re-sent to update the expiration) without being accessed or modified. This issue has been fixed in versions 2.3.2 and 2.2.5.
high | src/loadgenerator/requirements.txt | urllib3 | [CVE-2023-43804](https://nvd.nist.gov/vuln/detail/CVE-2023-43804) | 8.1 | fixed in 2.0.6, 1.26.17 | urllib3 is a user-friendly HTTP client library for Python. urllib3 doesn\'t treat the `Cookie` HTTP header special or provide any helpers for managing cookies over HTTP, that is the responsibility of the user. However, it is possible for a user to specify a `Cookie` header and unknowingly leak information via HTTP redirects to a different origin if that user doesn\'t disable redirects explicitly. This issue has been patched in urllib3 version 1.26.17 or 2.0.5.
high | src/loadgenerator/requirements.txt | werkzeug | [CVE-2023-25577](https://nvd.nist.gov/vuln/detail/CVE-2023-25577) | 7.5 | fixed in 2.2.3 | Werkzeug is a comprehensive WSGI web application library. Prior to version 2.2.3, Werkzeug\'s multipart form data parser will parse an unlimited number of parts, including file parts. Parts can be a small amount of bytes, but each requires CPU time to parse and may use more memory as Python data. If a request can be made to an endpoint that accesses `request.data`, `request.form`, `request.files`, or `request.get_data(parse_form_data=False)`, it can cause unexpectedly high resource usage. This allows an attacker to cause a denial of service by sending crafted multipart data to an endpoint that will parse it. The amount of CPU time required can block worker processes from handling legitimate requests. The amount of RAM required can trigger an out of memory kill of the process. Unlimited file parts can use up memory and file handles. If many concurrent requests are sent continuously, this can exhaust or kill all available workers. Version 2.2.3 contains a patch for this issue.
high | src/loadgenerator/requirements.txt | werkzeug | [CVE-2023-46136](https://nvd.nist.gov/vuln/detail/CVE-2023-46136) | 7.5 | fixed in 3.0.1 | Werkzeug is a comprehensive WSGI web application library. If an upload of a file that starts with CR or LF and then is followed by megabytes of data without these characters: all of these bytes are appended chunk by chunk into internal bytearray and lookup for boundary is performed on growing buffer. This allows an attacker to cause a denial of service by sending crafted multipart data to an endpoint that will parse it. The amount of CPU time required can block worker processes from handling legitimate requests. This vulnerability has been patched in version 3.0.1.
high | src/loadgenerator/requirements.txt | werkzeug | [PRISMA-2023-0035](https://github.com/pallets/werkzeug/issues/690) | 7.5 | fixed in 2.3.0 | The package werkzeug of versions from 0.9 up to 2.3.0 is vulnerable to DoS. The get_data() method does not verify the max_content_length property, therefore it being possible for a malicious actor to send arbitrarily large requests, leading to DoS. CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
high | src/recommendationservice/requirements.txt | grpcio | [CVE-2023-1428](https://nvd.nist.gov/vuln/detail/CVE-2023-1428) | 7.5 | fixed in 1.53.0 | There exists an vulnerability causing an abort() to be called in gRPC.u00a0 The following headers cause gRPC\'s C++ implementation to abort() when called via http2:  te: x (x != trailers)  :scheme: x (x != http, https)  grpclb_client_stats: x (x == anything)  On top of sending one of those headers, a later header must be sent that gets the total header size past 8KB. We recommend upgrading past git commitu00a02485fa94bd8a723e5c977d55a3ce10b301b437f8 or v1.53 and above.  
high | src/recommendationservice/requirements.txt | grpcio | [CVE-2023-32731](https://nvd.nist.gov/vuln/detail/CVE-2023-32731) | 7.4 | fixed in 1.53.0 | When gRPC HTTP2 stack raised a header size exceeded error, it skipped parsing the rest of the HPACK frame. This caused any HPACK table mutations to also be skipped, resulting in a desynchronization of HPACK tables between sender and receiver. If leveraged, say, between a proxy and a backend, this could lead to requests from the proxy being interpreted as containing headers from different proxy clients - leading to an information leak that can be used for privilege escalation or data exfiltration. We recommend upgrading beyond the commit contained inu00a0 https://github.com/grpc/grpc/pull/33005 https://github.com/grpc/grpc/pull/33005  
high | src/recommendationservice/requirements.txt | opentelemetry-instrumentation | [CVE-2023-43810](https://nvd.nist.gov/vuln/detail/CVE-2023-43810) | 7.5 | fixed in 0.41b0 | OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, logs. Autoinstrumentation out of the box adds the label `http_method` that has unbound cardinality. It leads to the server\'s potential memory exhaustion when many malicious requests are sent. HTTP method for requests can be easily set by an attacker to be random and long. In order to be affected program has to be instrumented for HTTP handlers and does not filter any unknown HTTP methods on the level of CDN, LB, previous middleware, etc. This issue has been patched in version 0.41b0.
high | src/recommendationservice/requirements.txt | urllib3 | [CVE-2023-43804](https://nvd.nist.gov/vuln/detail/CVE-2023-43804) | 8.1 | fixed in 2.0.6, 1.26.17 | urllib3 is a user-friendly HTTP client library for Python. urllib3 doesn\'t treat the `Cookie` HTTP header special or provide any helpers for managing cookies over HTTP, that is the responsibility of the user. However, it is possible for a user to specify a `Cookie` header and unknowingly leak information via HTTP redirects to a different origin if that user doesn\'t disable redirects explicitly. This issue has been patched in urllib3 version 1.26.17 or 2.0.5.
high | src/paymentservice/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | src/paymentservice/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | src/checkoutservice/go.sum | golang.org/x/crypto | [CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565) | 7.5 | fixed in 0.0.0-20211202192323-5770296d904e | The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an attacker to panic an SSH server.
high | src/checkoutservice/go.sum | golang.org/x/crypto | [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | 7.5 | fixed in 0.0.0-20220314234659-1baeb1ce4c0b | The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
high | src/checkoutservice/go.sum | golang.org/x/crypto | [CVE-2020-29652](https://nvd.nist.gov/vuln/detail/CVE-2020-29652) | 7.5 | fixed in 0.0.0-20201216223049-8b5274cf687f | A nil pointer dereference in the golang.org/x/crypto/ssh component through v0.0.0-20201203163018-be400aefbc4c for Go allows remote attackers to cause a denial of service against SSH servers.
high | src/checkoutservice/go.sum | go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc | [CVE-2023-47108](https://nvd.nist.gov/vuln/detail/CVE-2023-47108) | 7.5 | fixed in 0.46.0 | OpenTelemetry-Go Contrib is a collection of third-party packages for OpenTelemetry-Go. Prior to version 0.46.0, the grpc Unary Server Interceptor out of the box adds labels `net.peer.sock.addr` and `net.peer.sock.port` that have unbound cardinality. It leads to the server\'s potential memory exhaustion when many malicious requests are sent. An attacker can easily flood the peer address and port for requests. Version 0.46.0 contains a fix for this issue. As a workaround to stop being affected, a view removing the attributes can be used. The other possibility is to disable grpc metrics instrumentation by passing `otelgrpc.WithMeterProvider` option with `noop.NewMeterProvider`.
high | src/checkoutservice/go.sum | google.golang.org/grpc | [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) | 7.5 | fixed in 1.58.3, 1.57.1, 1.56.3 | ### Impact In affected releases of gRPC-Go, it is possible for an attacker to send HTTP/2 requests, cancel them, and send subsequent requests, which is valid by the HTTP/2 protocol, but would cause the gRPC-Go server to launch more concurrent method handlers than the configured maximum stream limit.  ### Patches This vulnerability was addressed by #6703 and has been included in patch releases: 1.56.3, 1.57.1, 1.58.3.  It is also included in the latest release, 1.59.0.  Along with applying the patch, users should also ensure they are using the `grpc.MaxConcurrentStreams` server option to apply a limit to the server\'s resources used for any single connection.  ### Workarounds None.  ### References #6703 
high | src/checkoutservice/go.sum | gopkg.in/yaml.v2 | [CVE-2022-3064](https://nvd.nist.gov/vuln/detail/CVE-2022-3064) | 7.5 | fixed in 2.2.4 | Parsing malicious or large YAML documents can consume excessive amounts of CPU or memory.
high | src/checkoutservice/go.sum | golang.org/x/net | [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | 7.5 | fixed in 0.7.0 | A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.
high | src/checkoutservice/go.sum | golang.org/x/net | [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | 7.5 | fixed in 0.17.0 | A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function.
high | src/frontend/go.sum | google.golang.org/grpc | [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) | 7.5 | fixed in 1.58.3, 1.57.1, 1.56.3 | ### Impact In affected releases of gRPC-Go, it is possible for an attacker to send HTTP/2 requests, cancel them, and send subsequent requests, which is valid by the HTTP/2 protocol, but would cause the gRPC-Go server to launch more concurrent method handlers than the configured maximum stream limit.  ### Patches This vulnerability was addressed by #6703 and has been included in patch releases: 1.56.3, 1.57.1, 1.58.3.  It is also included in the latest release, 1.59.0.  Along with applying the patch, users should also ensure they are using the `grpc.MaxConcurrentStreams` server option to apply a limit to the server\'s resources used for any single connection.  ### Workarounds None.  ### References #6703 
high | src/frontend/go.sum | gopkg.in/yaml.v2 | [CVE-2022-3064](https://nvd.nist.gov/vuln/detail/CVE-2022-3064) | 7.5 | fixed in 2.2.4 | Parsing malicious or large YAML documents can consume excessive amounts of CPU or memory.
high | src/frontend/go.sum | golang.org/x/crypto | [CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565) | 7.5 | fixed in 0.0.0-20211202192323-5770296d904e | The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an attacker to panic an SSH server.
high | src/frontend/go.sum | golang.org/x/crypto | [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | 7.5 | fixed in 0.0.0-20220314234659-1baeb1ce4c0b | The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
high | src/frontend/go.sum | golang.org/x/crypto | [CVE-2020-29652](https://nvd.nist.gov/vuln/detail/CVE-2020-29652) | 7.5 | fixed in 0.0.0-20201216223049-8b5274cf687f | A nil pointer dereference in the golang.org/x/crypto/ssh component through v0.0.0-20201203163018-be400aefbc4c for Go allows remote attackers to cause a denial of service against SSH servers.
high | src/frontend/go.sum | go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc | [CVE-2023-47108](https://nvd.nist.gov/vuln/detail/CVE-2023-47108) | 7.5 | fixed in 0.46.0 | OpenTelemetry-Go Contrib is a collection of third-party packages for OpenTelemetry-Go. Prior to version 0.46.0, the grpc Unary Server Interceptor out of the box adds labels `net.peer.sock.addr` and `net.peer.sock.port` that have unbound cardinality. It leads to the server\'s potential memory exhaustion when many malicious requests are sent. An attacker can easily flood the peer address and port for requests. Version 0.46.0 contains a fix for this issue. As a workaround to stop being affected, a view removing the attributes can be used. The other possibility is to disable grpc metrics instrumentation by passing `otelgrpc.WithMeterProvider` option with `noop.NewMeterProvider`.
high | src/frontend/go.sum | go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp | [CVE-2023-45142](https://nvd.nist.gov/vuln/detail/CVE-2023-45142) | 7.5 | fixed in 0.44.0 | OpenTelemetry-Go Contrib is a collection of third-party packages for OpenTelemetry-Go. A handler wrapper out of the box adds labels `http.user_agent` and `http.method` that have unbound cardinality. It leads to the server\'s potential memory exhaustion when many malicious requests are sent to it. HTTP header User-Agent or HTTP method for requests can be easily set by an attacker to be random and long. The library internally uses `httpconv.ServerRequest` that records every value for HTTP `method` and `User-Agent`. In order to be affected, a program has to use the `otelhttp.NewHandler` wrapper and not filter any unknown HTTP methods or User agents on the level of CDN, LB, previous middleware, etc. Version 0.44.0 fixed this issue when the values collected for attribute `http.request.method` were changed to be restricted to a set of well-known values and other high cardinality attributes were removed. As a workaround to stop being affected, `otelhttp.WithFilter()` can be used, but it requires manual careful configuration to not log certain requests entirely. For convenience and safe usage of this library, it should by default mark with the label `unknown` non-standard HTTP methods and User agents to show that such requests were made but do not increase cardinality. In case someone wants to stay with the current behavior, library API should allow to enable it.
high | src/frontend/go.sum | golang.org/x/net | [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | 7.5 | fixed in 0.7.0 | A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.
high | src/frontend/go.sum | golang.org/x/net | [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | 7.5 | fixed in 0.17.0 | A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function.
high | src/productcatalogservice/go.sum | google.golang.org/grpc | [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) | 7.5 | fixed in 1.58.3, 1.57.1, 1.56.3 | ### Impact In affected releases of gRPC-Go, it is possible for an attacker to send HTTP/2 requests, cancel them, and send subsequent requests, which is valid by the HTTP/2 protocol, but would cause the gRPC-Go server to launch more concurrent method handlers than the configured maximum stream limit.  ### Patches This vulnerability was addressed by #6703 and has been included in patch releases: 1.56.3, 1.57.1, 1.58.3.  It is also included in the latest release, 1.59.0.  Along with applying the patch, users should also ensure they are using the `grpc.MaxConcurrentStreams` server option to apply a limit to the server\'s resources used for any single connection.  ### Workarounds None.  ### References #6703 
high | src/productcatalogservice/go.sum | golang.org/x/crypto | [CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565) | 7.5 | fixed in 0.0.0-20211202192323-5770296d904e | The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an attacker to panic an SSH server.
high | src/productcatalogservice/go.sum | golang.org/x/crypto | [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | 7.5 | fixed in 0.0.0-20220314234659-1baeb1ce4c0b | The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
high | src/productcatalogservice/go.sum | golang.org/x/crypto | [CVE-2020-29652](https://nvd.nist.gov/vuln/detail/CVE-2020-29652) | 7.5 | fixed in 0.0.0-20201216223049-8b5274cf687f | A nil pointer dereference in the golang.org/x/crypto/ssh component through v0.0.0-20201203163018-be400aefbc4c for Go allows remote attackers to cause a denial of service against SSH servers.
high | src/productcatalogservice/go.sum | gopkg.in/yaml.v2 | [CVE-2022-3064](https://nvd.nist.gov/vuln/detail/CVE-2022-3064) | 7.5 | fixed in 2.2.4 | Parsing malicious or large YAML documents can consume excessive amounts of CPU or memory.
high | src/productcatalogservice/go.sum | golang.org/x/net | [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | 7.5 | fixed in 0.7.0 | A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.
high | src/productcatalogservice/go.sum | golang.org/x/net | [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | 7.5 | fixed in 0.17.0 | A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function.
high | src/productcatalogservice/go.sum | go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc | [CVE-2023-47108](https://nvd.nist.gov/vuln/detail/CVE-2023-47108) | 7.5 | fixed in 0.46.0 | OpenTelemetry-Go Contrib is a collection of third-party packages for OpenTelemetry-Go. Prior to version 0.46.0, the grpc Unary Server Interceptor out of the box adds labels `net.peer.sock.addr` and `net.peer.sock.port` that have unbound cardinality. It leads to the server\'s potential memory exhaustion when many malicious requests are sent. An attacker can easily flood the peer address and port for requests. Version 0.46.0 contains a fix for this issue. As a workaround to stop being affected, a view removing the attributes can be used. The other possibility is to disable grpc metrics instrumentation by passing `otelgrpc.WithMeterProvider` option with `noop.NewMeterProvider`.
high | src/shippingservice/go.sum | golang.org/x/net | [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | 7.5 | fixed in 0.7.0 | A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.
high | src/shippingservice/go.sum | golang.org/x/net | [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | 7.5 | fixed in 0.17.0 | A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function.
high | src/shippingservice/go.sum | golang.org/x/crypto | [CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565) | 7.5 | fixed in 0.0.0-20211202192323-5770296d904e | The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an attacker to panic an SSH server.
high | src/shippingservice/go.sum | golang.org/x/crypto | [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | 7.5 | fixed in 0.0.0-20220314234659-1baeb1ce4c0b | The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
high | src/shippingservice/go.sum | golang.org/x/crypto | [CVE-2020-29652](https://nvd.nist.gov/vuln/detail/CVE-2020-29652) | 7.5 | fixed in 0.0.0-20201216223049-8b5274cf687f | A nil pointer dereference in the golang.org/x/crypto/ssh component through v0.0.0-20201203163018-be400aefbc4c for Go allows remote attackers to cause a denial of service against SSH servers.
high | src/shippingservice/go.sum | google.golang.org/grpc | [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) | 7.5 | fixed in 1.58.3, 1.57.1, 1.56.3 | ### Impact In affected releases of gRPC-Go, it is possible for an attacker to send HTTP/2 requests, cancel them, and send subsequent requests, which is valid by the HTTP/2 protocol, but would cause the gRPC-Go server to launch more concurrent method handlers than the configured maximum stream limit.  ### Patches This vulnerability was addressed by #6703 and has been included in patch releases: 1.56.3, 1.57.1, 1.58.3.  It is also included in the latest release, 1.59.0.  Along with applying the patch, users should also ensure they are using the `grpc.MaxConcurrentStreams` server option to apply a limit to the server\'s resources used for any single connection.  ### Workarounds None.  ### References #6703 
high | src/shippingservice/go.sum | gopkg.in/yaml.v3 | [CVE-2022-28948](https://nvd.nist.gov/vuln/detail/CVE-2022-28948) | 7.5 | fixed in 3.0.0-20220521103104-8f96da9f5d5e | An issue in the Unmarshal function in Go-Yaml v3 causes the program to crash when attempting to deserialize invalid input.
moderate | src/emailservice/requirements.txt | grpcio | [CVE-2023-32732](https://nvd.nist.gov/vuln/detail/CVE-2023-32732) | 5.3 | fixed in 1.53.0 | gRPC contains a vulnerability whereby a client can cause a termination of connection between a HTTP2 proxy and a gRPC server: a base64 encoding error for `-bin` suffixed headers will result in a disconnection by the gRPC server, but is typically allowed by HTTP2 proxies. We recommend upgrading beyond the commit inu00a0 https://github.com/grpc/grpc/pull/32309 https://www.google.com/url  
medium | src/emailservice/requirements.txt | requests | [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681) | 6.1 | fixed in 2.31.0 | Requests is a HTTP library. Since Requests 2.3.0, Requests has been leaking Proxy-Authorization headers to destination servers when redirected to an HTTPS endpoint. This is a product of how we use `rebuild_proxies` to reattach the `Proxy-Authorization` header to requests. For HTTP connections sent through the tunnel, the proxy will identify the header in the request itself and remove it prior to forwarding to the destination server. However when sent over HTTPS, the `Proxy-Authorization` header must be sent in the CONNECT request as the proxy has no visibility into the tunneled request. This results in Requests forwarding proxy credentials to the destination server unintentionally, allowing a malicious actor to potentially exfiltrate sensitive information. This issue has been patched in version 2.31.0.  
medium | src/emailservice/requirements.txt | urllib3 | [CVE-2023-45803](https://nvd.nist.gov/vuln/detail/CVE-2023-45803) | 4.2 | fixed in 2.0.7, 1.26.18 | urllib3 is a user-friendly HTTP client library for Python. urllib3 previously wouldn\'t remove the HTTP request body when an HTTP redirect response using status 301, 302, or 303 after the request had its method changed from one that could accept a request body (like `POST`) to `GET` as is required by HTTP RFCs. Although this behavior is not specified in the section for redirects, it can be inferred by piecing together information from different sections and we have observed the behavior in other major HTTP client implementations like curl and web browsers. Because the vulnerability requires a previously trusted service to become compromised in order to have an impact on confidentiality we believe the exploitability of this vulnerability is low. Additionally, many users aren\'t putting sensitive data in HTTP request bodies, if this is the case then this vulnerability isn\'t exploitable. Both of the following conditions must be true to be affected by this vulnerability: 1. Using urllib3 and submitting sensitive information in the HTTP request body (such as form data or JSON) and 2. The origin service is compromised and starts redirecting using 301, 302, or 303 to a malicious peer or the redirected-to service becomes compromised. This issue has been addressed in versions 1.26.18 and 2.0.7 and users are advised to update to resolve this issue. Users unable to update should disable red
medium | src/loadgenerator/requirements.txt | requests | [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681) | 6.1 | fixed in 2.31.0 | Requests is a HTTP library. Since Requests 2.3.0, Requests has been leaking Proxy-Authorization headers to destination servers when redirected to an HTTPS endpoint. This is a product of how we use `rebuild_proxies` to reattach the `Proxy-Authorization` header to requests. For HTTP connections sent through the tunnel, the proxy will identify the header in the request itself and remove it prior to forwarding to the destination server. However when sent over HTTPS, the `Proxy-Authorization` header must be sent in the CONNECT request as the proxy has no visibility into the tunneled request. This results in Requests forwarding proxy credentials to the destination server unintentionally, allowing a malicious actor to potentially exfiltrate sensitive information. This issue has been patched in version 2.31.0.  
medium | src/loadgenerator/requirements.txt | urllib3 | [CVE-2023-45803](https://nvd.nist.gov/vuln/detail/CVE-2023-45803) | 4.2 | fixed in 2.0.7, 1.26.18 | urllib3 is a user-friendly HTTP client library for Python. urllib3 previously wouldn\'t remove the HTTP request body when an HTTP redirect response using status 301, 302, or 303 after the request had its method changed from one that could accept a request body (like `POST`) to `GET` as is required by HTTP RFCs. Although this behavior is not specified in the section for redirects, it can be inferred by piecing together information from different sections and we have observed the behavior in other major HTTP client implementations like curl and web browsers. Because the vulnerability requires a previously trusted service to become compromised in order to have an impact on confidentiality we believe the exploitability of this vulnerability is low. Additionally, many users aren\'t putting sensitive data in HTTP request bodies, if this is the case then this vulnerability isn\'t exploitable. Both of the following conditions must be true to be affected by this vulnerability: 1. Using urllib3 and submitting sensitive information in the HTTP request body (such as form data or JSON) and 2. The origin service is compromised and starts redirecting using 301, 302, or 303 to a malicious peer or the redirected-to service becomes compromised. This issue has been addressed in versions 1.26.18 and 2.0.7 and users are advised to update to resolve this issue. Users unable to update should disable red
moderate | src/recommendationservice/requirements.txt | grpcio | [CVE-2023-32732](https://nvd.nist.gov/vuln/detail/CVE-2023-32732) | 5.3 | fixed in 1.53.0 | gRPC contains a vulnerability whereby a client can cause a termination of connection between a HTTP2 proxy and a gRPC server: a base64 encoding error for `-bin` suffixed headers will result in a disconnection by the gRPC server, but is typically allowed by HTTP2 proxies. We recommend upgrading beyond the commit inu00a0 https://github.com/grpc/grpc/pull/32309 https://www.google.com/url  
medium | src/recommendationservice/requirements.txt | requests | [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681) | 6.1 | fixed in 2.31.0 | Requests is a HTTP library. Since Requests 2.3.0, Requests has been leaking Proxy-Authorization headers to destination servers when redirected to an HTTPS endpoint. This is a product of how we use `rebuild_proxies` to reattach the `Proxy-Authorization` header to requests. For HTTP connections sent through the tunnel, the proxy will identify the header in the request itself and remove it prior to forwarding to the destination server. However when sent over HTTPS, the `Proxy-Authorization` header must be sent in the CONNECT request as the proxy has no visibility into the tunneled request. This results in Requests forwarding proxy credentials to the destination server unintentionally, allowing a malicious actor to potentially exfiltrate sensitive information. This issue has been patched in version 2.31.0.  
medium | src/recommendationservice/requirements.txt | urllib3 | [CVE-2023-45803](https://nvd.nist.gov/vuln/detail/CVE-2023-45803) | 4.2 | fixed in 2.0.7, 1.26.18 | urllib3 is a user-friendly HTTP client library for Python. urllib3 previously wouldn\'t remove the HTTP request body when an HTTP redirect response using status 301, 302, or 303 after the request had its method changed from one that could accept a request body (like `POST`) to `GET` as is required by HTTP RFCs. Although this behavior is not specified in the section for redirects, it can be inferred by piecing together information from different sections and we have observed the behavior in other major HTTP client implementations like curl and web browsers. Because the vulnerability requires a previously trusted service to become compromised in order to have an impact on confidentiality we believe the exploitability of this vulnerability is low. Additionally, many users aren\'t putting sensitive data in HTTP request bodies, if this is the case then this vulnerability isn\'t exploitable. Both of the following conditions must be true to be affected by this vulnerability: 1. Using urllib3 and submitting sensitive information in the HTTP request body (such as form data or JSON) and 2. The origin service is compromised and starts redirecting using 301, 302, or 303 to a malicious peer or the redirected-to service becomes compromised. This issue has been addressed in versions 1.26.18 and 2.0.7 and users are advised to update to resolve this issue. Users unable to update should disable red
moderate | src/checkoutservice/go.sum | golang.org/x/crypto | [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | 5.9 | fixed in 0.17.0 | a flaw was found in the ssh channel integrity. by manipulating sequence numbers during the handshake, an attacker can remove the initial messages on the secure channel without causing a mac failure. for example, an attacker could disable the ping extension and thus disable the new countermeasure in openssh 9.5 against keystroke timing attacks.
moderate | src/checkoutservice/go.sum | google.golang.org/grpc | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 1.56.3, 1.57.1, 1.58.3 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
medium | src/checkoutservice/go.sum | github.com/sirupsen/logrus | [PRISMA-2023-0056](https://github.com/sirupsen/logrus/issues/1370) | 6.2 | fixed in v1.9.3 | The github.com/sirupsen/logrus module of all versions is vulnerable to denial of service. Logging more than 64kb of data in a single entry without newlines causes the log writer function to hang indefinitely.
moderate | src/checkoutservice/go.sum | golang.org/x/image | [CVE-2022-41727](https://nvd.nist.gov/vuln/detail/CVE-2022-41727) | 5.5 | fixed in 0.5.0 | An attacker can craft a malformed TIFF image which will consume a significant amount of memory when passed to DecodeConfig. This could lead to a denial of service.
moderate | src/checkoutservice/go.sum | golang.org/x/image | [CVE-2023-29408](https://nvd.nist.gov/vuln/detail/CVE-2023-29408) | 6.5 | fixed in 0.10.0 | The TIFF decoder does not place a limit on the size of compressed tile data. A maliciously-crafted image can exploit this to cause a small image (both in terms of pixel width/height, and encoded size) to make the decoder decode large amounts of compressed data, consuming excessive memory and CPU.
moderate | src/checkoutservice/go.sum | golang.org/x/image | [CVE-2023-29407](https://nvd.nist.gov/vuln/detail/CVE-2023-29407) | 6.5 | fixed in 0.10.0 | A maliciously-crafted image can cause excessive CPU consumption in decoding. A tiled image with a height of 0 and a very large width can cause excessive CPU consumption, despite the image size (width * height) appearing to be zero.
moderate | src/checkoutservice/go.sum | gopkg.in/yaml.v2 | [CVE-2019-11254](https://nvd.nist.gov/vuln/detail/CVE-2019-11254) | 6.5 | fixed in 2.2.8 | The Kubernetes API Server component in versions 1.1-1.14, and versions prior to 1.15.10, 1.16.7 and 1.17.3 allows an authorized user who sends malicious YAML payloads to cause the kube-apiserver to consume excessive CPU cycles while parsing YAML.
moderate | src/checkoutservice/go.sum | golang.org/x/net | [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | 6.1 | fixed in 0.13.0 | Text nodes not in the HTML namespace are incorrectly literally rendered, causing text which should be escaped to not be. This could lead to an XSS attack.
moderate | src/checkoutservice/go.sum | golang.org/x/net | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 0.17.0 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
medium | src/frontend/go.sum | github.com/sirupsen/logrus | [PRISMA-2023-0056](https://github.com/sirupsen/logrus/issues/1370) | 6.2 | fixed in v1.9.3 | The github.com/sirupsen/logrus module of all versions is vulnerable to denial of service. Logging more than 64kb of data in a single entry without newlines causes the log writer function to hang indefinitely.
moderate | src/frontend/go.sum | google.golang.org/grpc | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 1.56.3, 1.57.1, 1.58.3 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
moderate | src/frontend/go.sum | gopkg.in/yaml.v2 | [CVE-2019-11254](https://nvd.nist.gov/vuln/detail/CVE-2019-11254) | 6.5 | fixed in 2.2.8 | The Kubernetes API Server component in versions 1.1-1.14, and versions prior to 1.15.10, 1.16.7 and 1.17.3 allows an authorized user who sends malicious YAML payloads to cause the kube-apiserver to consume excessive CPU cycles while parsing YAML.
moderate | src/frontend/go.sum | golang.org/x/crypto | [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | 5.9 | fixed in 0.17.0 | a flaw was found in the ssh channel integrity. by manipulating sequence numbers during the handshake, an attacker can remove the initial messages on the secure channel without causing a mac failure. for example, an attacker could disable the ping extension and thus disable the new countermeasure in openssh 9.5 against keystroke timing attacks.
moderate | src/frontend/go.sum | golang.org/x/image | [CVE-2022-41727](https://nvd.nist.gov/vuln/detail/CVE-2022-41727) | 5.5 | fixed in 0.5.0 | An attacker can craft a malformed TIFF image which will consume a significant amount of memory when passed to DecodeConfig. This could lead to a denial of service.
moderate | src/frontend/go.sum | golang.org/x/image | [CVE-2023-29408](https://nvd.nist.gov/vuln/detail/CVE-2023-29408) | 6.5 | fixed in 0.10.0 | The TIFF decoder does not place a limit on the size of compressed tile data. A maliciously-crafted image can exploit this to cause a small image (both in terms of pixel width/height, and encoded size) to make the decoder decode large amounts of compressed data, consuming excessive memory and CPU.
moderate | src/frontend/go.sum | golang.org/x/image | [CVE-2023-29407](https://nvd.nist.gov/vuln/detail/CVE-2023-29407) | 6.5 | fixed in 0.10.0 | A maliciously-crafted image can cause excessive CPU consumption in decoding. A tiled image with a height of 0 and a very large width can cause excessive CPU consumption, despite the image size (width * height) appearing to be zero.
moderate | src/frontend/go.sum | golang.org/x/net | [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | 6.1 | fixed in 0.13.0 | Text nodes not in the HTML namespace are incorrectly literally rendered, causing text which should be escaped to not be. This could lead to an XSS attack.
moderate | src/frontend/go.sum | golang.org/x/net | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 0.17.0 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
moderate | src/productcatalogservice/go.sum | google.golang.org/grpc | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 1.56.3, 1.57.1, 1.58.3 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
moderate | src/productcatalogservice/go.sum | golang.org/x/crypto | [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | 5.9 | fixed in 0.17.0 | a flaw was found in the ssh channel integrity. by manipulating sequence numbers during the handshake, an attacker can remove the initial messages on the secure channel without causing a mac failure. for example, an attacker could disable the ping extension and thus disable the new countermeasure in openssh 9.5 against keystroke timing attacks.
moderate | src/productcatalogservice/go.sum | gopkg.in/yaml.v2 | [CVE-2019-11254](https://nvd.nist.gov/vuln/detail/CVE-2019-11254) | 6.5 | fixed in 2.2.8 | The Kubernetes API Server component in versions 1.1-1.14, and versions prior to 1.15.10, 1.16.7 and 1.17.3 allows an authorized user who sends malicious YAML payloads to cause the kube-apiserver to consume excessive CPU cycles while parsing YAML.
moderate | src/productcatalogservice/go.sum | golang.org/x/net | [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | 6.1 | fixed in 0.13.0 | Text nodes not in the HTML namespace are incorrectly literally rendered, causing text which should be escaped to not be. This could lead to an XSS attack.
moderate | src/productcatalogservice/go.sum | golang.org/x/net | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 0.17.0 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
medium | src/productcatalogservice/go.sum | github.com/sirupsen/logrus | [PRISMA-2023-0056](https://github.com/sirupsen/logrus/issues/1370) | 6.2 | fixed in v1.9.3 | The github.com/sirupsen/logrus module of all versions is vulnerable to denial of service. Logging more than 64kb of data in a single entry without newlines causes the log writer function to hang indefinitely.
moderate | src/productcatalogservice/go.sum | golang.org/x/image | [CVE-2022-41727](https://nvd.nist.gov/vuln/detail/CVE-2022-41727) | 5.5 | fixed in 0.5.0 | An attacker can craft a malformed TIFF image which will consume a significant amount of memory when passed to DecodeConfig. This could lead to a denial of service.
moderate | src/productcatalogservice/go.sum | golang.org/x/image | [CVE-2023-29408](https://nvd.nist.gov/vuln/detail/CVE-2023-29408) | 6.5 | fixed in 0.10.0 | The TIFF decoder does not place a limit on the size of compressed tile data. A maliciously-crafted image can exploit this to cause a small image (both in terms of pixel width/height, and encoded size) to make the decoder decode large amounts of compressed data, consuming excessive memory and CPU.
moderate | src/productcatalogservice/go.sum | golang.org/x/image | [CVE-2023-29407](https://nvd.nist.gov/vuln/detail/CVE-2023-29407) | 6.5 | fixed in 0.10.0 | A maliciously-crafted image can cause excessive CPU consumption in decoding. A tiled image with a height of 0 and a very large width can cause excessive CPU consumption, despite the image size (width * height) appearing to be zero.
medium | src/shippingservice/go.sum | github.com/sirupsen/logrus | [PRISMA-2023-0056](https://github.com/sirupsen/logrus/issues/1370) | 6.2 | fixed in v1.9.3 | The github.com/sirupsen/logrus module of all versions is vulnerable to denial of service. Logging more than 64kb of data in a single entry without newlines causes the log writer function to hang indefinitely.
moderate | src/shippingservice/go.sum | golang.org/x/net | [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | 6.1 | fixed in 0.13.0 | Text nodes not in the HTML namespace are incorrectly literally rendered, causing text which should be escaped to not be. This could lead to an XSS attack.
moderate | src/shippingservice/go.sum | golang.org/x/net | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 0.17.0 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
moderate | src/shippingservice/go.sum | golang.org/x/crypto | [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | 5.9 | fixed in 0.17.0 | a flaw was found in the ssh channel integrity. by manipulating sequence numbers during the handshake, an attacker can remove the initial messages on the secure channel without causing a mac failure. for example, an attacker could disable the ping extension and thus disable the new countermeasure in openssh 9.5 against keystroke timing attacks.
moderate | src/shippingservice/go.sum | google.golang.org/grpc | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 1.56.3, 1.57.1, 1.58.3 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
low | src/loadgenerator/requirements.txt | werkzeug | [CVE-2023-23934](https://nvd.nist.gov/vuln/detail/CVE-2023-23934) | 3.5 | fixed in 2.2.3 | Werkzeug is a comprehensive WSGI web application library. Browsers may allow \"nameless\" cookies that look like `=value` instead of `key=value`. A vulnerable browser may allow a compromised application on an adjacent subdomain to exploit this to set a cookie like `=__Host-test=bad` for another subdomain. Werkzeug prior to 2.2.3 will parse the cookie `=__Host-test=bad` as __Host-test=bad`. If a Werkzeug application is running next to a vulnerable or malicious subdomain which sets such a cookie using a vulnerable browser, the Werkzeug application will see the bad cookie value but the valid cookie key. The issue is fixed in Werkzeug 2.2.3.
